### PR TITLE
update swift tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "SwiftClibxml2",
     pkgConfig: "libxml-2.0",
     providers: [
-        .Brew("libxml2"),
-        .Apt("libxml2-dev")
+        .brew(["libxml2"]),
+        .apt(["libxml2-dev"])
     ]
 )


### PR DESCRIPTION
Because, swift tools version 3.x is not supporting in swift 5.

This library is depends by [SwiftGen/SwiftGen](https://github.com/SwiftGen/SwiftGen) , and this problem makes a new issue https://github.com/SwiftGen/SwiftGen/issues/580#issuecomment-479777954